### PR TITLE
Only update `tap-google-ads.api-field-names` metadata when available

### DIFF
--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -85,7 +85,7 @@ def get_selected_fields(stream_mdata):
         if mdata["breadcrumb"]:
             inclusion = mdata["metadata"].get("inclusion")
             selected = mdata["metadata"].get("selected")
-            if utils.should_sync_field(inclusion, selected) and mdata["breadcrumb"][1] != "_sdc_record_hash":
+            if utils.should_sync_field(inclusion, selected) and mdata["breadcrumb"][1] != "_sdc_record_hash" and mdata["metadata"].get("tap-google-ads.api-field-names") is not None:
                 selected_fields.update(mdata["metadata"]["tap-google-ads.api-field-names"])
 
     return selected_fields


### PR DESCRIPTION
# Description of change
The function `get_selected_fields` in method in `streams.py` assumes that every selected field has a `tap-google-ads.api-field-names`, which is not always true, causing the `sync` to fail with `KeyError: 'tap-google-ads.api-field-names'`.

This PR changes the tap code to ensure that this update only runs when the property is available.
